### PR TITLE
chore: remove release workflow condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   release:
-    if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR aims to remove the condition to run the release workflow, which should be done in #3 