### PR TITLE
chore: update repository url for semantic-release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,6 @@
 {
   "branches": "main",
-  "repositoryUrl": "git@github.com:3kezoh/dark-high-contrast.git",
+  "repositoryUrl": "https://github.com/3kezoh/dark-high-contrast.git",
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
This PR aims to update the repository url to use the https version over the ssh.